### PR TITLE
[BOOKAROOM-55] Show swipe guides only one time

### DIFF
--- a/comeet/Data/Persistor/PersistorProtocol.swift
+++ b/comeet/Data/Persistor/PersistorProtocol.swift
@@ -14,4 +14,6 @@ protocol PersistorProtocol {
     func getMetroArea() -> String?
     func save(roomlist: User?)
     func getRoomlist() -> User?
+    func roomSwipeGuideWasPresented() -> Bool
+    func agendaSwipeGuideWasPresented() -> Bool
 }

--- a/comeet/Data/Persistor/PersistorUserDefaultsImplementer.swift
+++ b/comeet/Data/Persistor/PersistorUserDefaultsImplementer.swift
@@ -14,6 +14,8 @@ class PersistorUserDefaultsImplementer : PersistorProtocol {
         static let metroAreaKey = "metroAreaKey"
         static let roomlistNameKey = "roomlistNameKey"
         static let roomlistEmailKey = "roomlistEmailKey"
+        static let roomSwipeGuideWasPresentedKey = "roomSwipeGuideWasPresentedKey"
+        static let agendaSwipeGuideWasPresentedKey = "agendaSwipeGuideWasPresentedKey"
     }
     
     func save(metroArea: String?) {
@@ -44,5 +46,19 @@ class PersistorUserDefaultsImplementer : PersistorProtocol {
         
         let user = User(name: name, email: email)
         return user
+    }
+    
+    func roomSwipeGuideWasPresented() -> Bool {
+        let showSwipe = UserDefaults.standard.bool(forKey: Constants.roomSwipeGuideWasPresentedKey)
+        UserDefaults.standard.set(true, forKey: Constants.roomSwipeGuideWasPresentedKey)
+        UserDefaults.standard.synchronize()
+        return showSwipe
+    }
+    
+    func agendaSwipeGuideWasPresented() -> Bool {
+        let showSwipe = UserDefaults.standard.bool(forKey: Constants.agendaSwipeGuideWasPresentedKey)
+        UserDefaults.standard.set(true, forKey: Constants.agendaSwipeGuideWasPresentedKey)
+        UserDefaults.standard.synchronize()
+        return showSwipe
     }
 }

--- a/comeet/UI/Base/BaseViewController.swift
+++ b/comeet/UI/Base/BaseViewController.swift
@@ -35,4 +35,16 @@ class BaseViewController: UIViewController {
         mapItem.name = name
         mapItem.openInMaps(launchOptions: options)
     }
+    
+    func showTemporarily(view: UIView) {
+        view.isHidden = false
+        view.alpha = 1.0
+        UIView.animate(withDuration: 0.5, delay: 3.0, options: [], animations: {
+            view.alpha = 0.0
+        }) { (completion: Bool) in
+            if completion {
+                view.isHidden = true
+            }
+        }
+    }
 }

--- a/comeet/UI/MyAgenda/MyAgendaViewController.swift
+++ b/comeet/UI/MyAgenda/MyAgendaViewController.swift
@@ -26,22 +26,8 @@ class MyAgendaViewController: BaseViewController {
     }
     
     override func viewWillAppear(_ animated: Bool) {
-        if let vm = viewModel {
-            if vm.showGuide  {
-                let when = DispatchTime.now() + 3 // change 2 to desired number of seconds
-                DispatchQueue.main.asyncAfter(deadline: when) { [weak self] () in
-                    // Your code with delay
-                    if let s = self {
-                        if ( s.guideView.isHidden == false) {
-                            s.guideView.isHidden = true
-                        }
-                        s.viewModel?.showGuide = false
-                    }
-                }
-            } else {
-                self.guideView.isHidden = true;
-            }
-        }
+        super.viewWillAppear(animated)
+        showSwipeGuide()
     }
     
     override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
@@ -80,6 +66,14 @@ private extension MyAgendaViewController {
         if let selectedSection = viewModel?.selectedSection(), let position = UITableViewScrollPosition(rawValue: selectedSection) {
             tableView.scrollToRow(at: IndexPath(row: 0, section: selectedSection), at: position, animated: true)
         }
+    }
+    
+    func showSwipeGuide() {
+        guideView.isHidden = true
+        guard let showGuide = viewModel?.showSwipeGuide(), showGuide == true else {
+            return
+        }
+        showTemporarily(view: guideView)
     }
 }
 

--- a/comeet/UI/RoomsList/RoomsListViewController.swift
+++ b/comeet/UI/RoomsList/RoomsListViewController.swift
@@ -76,23 +76,6 @@ class RoomsListViewController: BaseViewController {
     func newLocation(sender: Any) {
         viewModel?.newLocation(metroarea: Router.selectedMetroarea, roomsList: Router.selectedRoomsList)
         selectLocationButton.setTitle(viewModel?.roomsList?.name, for: .normal)
-        
-        let userDefault = UserDefaults.standard
-        userDefault.set(false, forKey: "isRoomsGuideShown")
-        self.guideView.isHidden = false
-        let isGuideShown = userDefault.bool(forKey: "isRoomsGuideShown")
-        if (!isGuideShown) {
-            let when = DispatchTime.now() + 3
-            DispatchQueue.main.asyncAfter(deadline: when) {
-                if ( self.guideView.isHidden == false) {
-                    self.guideView.isHidden = true
-                }
-                userDefault.set(true, forKey: "isRoomsGuideShown")
-            }
-        } else {
-            self.guideView.isHidden = true
-        }
-        
     }
     
     func book(sender: Any) {
@@ -148,6 +131,7 @@ private extension RoomsListViewController {
         title = viewModel.title()
         
         viewModel.reloadBinding = { [weak self] in
+            self?.showSwipeGuide()
             self?.tableView.reloadSections([0], with: UITableViewRowAnimation.fade)
         }
         viewModel.fetchRooms()
@@ -161,6 +145,14 @@ private extension RoomsListViewController {
         } else {
             performSegue(withIdentifier: Router.Constants.metroareaSegue, sender: self)
         }
+    }
+    
+    func showSwipeGuide() {
+        guideView.isHidden = true
+        guard let showGuide = viewModel?.showSwipeGuide(), showGuide == true else {
+            return
+        }
+        showTemporarily(view: guideView)
     }
     
     func setupSlider() {

--- a/comeet/UI/RoomsList/RoomsListViewController.swift
+++ b/comeet/UI/RoomsList/RoomsListViewController.swift
@@ -192,6 +192,8 @@ extension RoomsListViewController : UITableViewDataSource {
         }
         
         roomCell.bookButton.tag = indexPath.row
+        roomCell.mapButton.tag = indexPath.row
+        roomCell.floorPlanButton.tag = indexPath.row
         roomCell.roomName.text = viewModel?.roomName(index: indexPath.row)
         roomCell.roomCapacity.text = viewModel?.roomDescription(index: indexPath.row)
         roomCell.bookButton.addTarget(self, action: #selector(book(sender:)), for: .touchUpInside)

--- a/comeet/UI/RoomsList/RoomsListViewModel.swift
+++ b/comeet/UI/RoomsList/RoomsListViewModel.swift
@@ -193,6 +193,10 @@ class RoomsListViewModel : BaseViewModel {
             return false
         }
     }
+    
+    func showSwipeGuide() -> Bool {
+        return !persistor.roomSwipeGuideWasPresented()
+    }
 }
 
 private extension RoomsListViewModel {
@@ -219,10 +223,11 @@ private extension RoomsListViewModel {
     }
     
     func removeRooms() {
-        if (!testing) {
-            rooms = []
-            reloadBinding?()
+        guard !testing, rooms.count > 0 else {
+            return
         }
+        rooms = []
+        reloadBinding?()
     }
     
     func showLoading() {

--- a/comeet/UI/Router/MyAgendaViewModel.swift
+++ b/comeet/UI/Router/MyAgendaViewModel.swift
@@ -54,17 +54,8 @@ class MyAgendaViewModel : BaseViewModel {
         }
     }
     
-    /// Whethere to show the guide graphic.
-    var showGuide : Bool {
-        get {
-            let userDefault = UserDefaults.standard
-            let isGuideShown = userDefault.bool(forKey: "isAgendaGuideShown")
-            return !isGuideShown
-        }
-        set {
-            let userDefault = UserDefaults.standard
-            userDefault.set(newValue, forKey: "isAgendaGuideShown")
-        }
+    func showSwipeGuide() -> Bool {
+        return !persistor.agendaSwipeGuideWasPresented()
     }
     
     func sectionsCount() -> Int {

--- a/comeetTests/UI/Fakes/FakePersistor.swift
+++ b/comeetTests/UI/Fakes/FakePersistor.swift
@@ -29,4 +29,12 @@ class FakePersistor : PersistorProtocol {
     func getRoomlist() -> User? {
         return roomlist
     }
+    
+    func roomSwipeGuideWasPresented() -> Bool {
+        return true
+    }
+    
+    func agendaSwipeGuideWasPresented() -> Bool {
+        return true
+    }
 }


### PR DESCRIPTION
https://bookaroom.atlassian.net/browse/BOOKAROOM-55

Upon every fresh install the swipe guides for room and agenda will show only once. 
* Room swipe guide will be shown after the first fetch of rooms occurs and the loading is dismissed.
* Agenda swipe guide will be shown the first time the users swipes to My Agenda. 

Also fixes an unrelated issue with the map and floor plan button son the list of rooms.
